### PR TITLE
Cleaned up error handling in places

### DIFF
--- a/examples/create_index.rs
+++ b/examples/create_index.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = EsClient::default();
 
     // Create index.
-    let index_future = create_index_req(&client, "test4");
+    let index_future = create_index_req(&client, "test");
     let index = rt.block_on(index_future)?;
     println!("{:?}", index);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -38,8 +38,11 @@ impl Default for EsClient {
             version: Version::Es6,
         };
         // Use client to get version and update version field.
-        let version = client.get_version().unwrap();
-        client.version = version;
+        let version = client.get_version();
+        match version {
+            Ok(version) => client.version = version,
+            Err(error) => panic!("Failed to extract version! {:?}", error)
+        };
         client
     }
 }
@@ -60,8 +63,11 @@ impl EsClient {
             version: Version::Es6,
         };
         // Use client to get version and update version field
-        let version = client.get_version().unwrap();
-        client.version = version;
+        let version = client.get_version();
+        match version {
+            Ok(version) => client.version = version,
+            Err(error) => panic!("Failed to extract version! {:?}", error)
+        };
         client
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -64,6 +64,11 @@ pub async fn search_req<T>(client: &EsClient, index: &str, doc_type: Option<&str
             let data = serialize_response::<ESGenericFail>(&text)?;
             return Err(Box::new(data));
         },
+        StatusCode::NOT_FOUND => {
+            let text = res.text().await?;
+            let data = serialize_response::<ESGenericFail>(&text)?;
+            return Err(Box::new(data));
+        }
         _ => panic!("Request failed in an unexpected way..."),
     };
     Ok(res)


### PR DESCRIPTION
# Overview
When ES was not running or index was not created, default behaviour was to panic!. ES unavailable still panics but provides more clear messaging.